### PR TITLE
Updated: Get Product manage_stock attribute to return a bool

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -65,6 +65,17 @@ Yes, the plugin supports uploading images to the WordPress media library via the
 
 ## Changelog
 
+### 1.0.11
+* Updated: [Get Product](https://www.polyplugins.com/docs/content-api/api/get-product/) manage_stock attribute to return a bool
+* Updated: [Update Product](https://www.polyplugins.com/docs/content-api/api/update-product/) manage_stock attribute to be able to use bool
+* Updated: [Create Product](https://www.polyplugins.com/docs/content-api/api/create-product/) manage_stock attribute to be able to use bool
+* Bugfix: [Update Product](https://www.polyplugins.com/docs/content-api/api/update-product/) attributes attribute not creating product attributes when they don't exist.
+* Bugfix: [Create Product](https://www.polyplugins.com/docs/content-api/api/create-product/) attributes attribute not creating product attributes when they don't exist.
+* Bugfix: [Update Product](https://www.polyplugins.com/docs/content-api/api/update-product/) triggering error sku during slug check
+* Bugfix: [Create Product](https://www.polyplugins.com/docs/content-api/api/create-product/) triggering error sku during slug check
+* Bugfix: [Update Product](https://www.polyplugins.com/docs/content-api/api/update-product/) triggering Exception instead of WP Error when upc attribute is already in use
+* Bugfix: [Create Product](https://www.polyplugins.com/docs/content-api/api/create-product/) triggering Exception instead of WP Error when upc attribute is already in use
+
 ### 1.0.10
 * Updated: [Create Product](https://www.polyplugins.com/docs/content-api/api/create-product/) endpoint to not require quantity
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: polyplugins
 Tags: content api, rest api, content, creative, api
 Tested up to: 6.8
-Stable tag: 1.0.10
+Stable tag: 1.0.11
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -83,6 +83,17 @@ Yes, the plugin supports uploading images to the WordPress media library via the
 
 
 == Changelog ==
+
+= 1.0.11 =
+* Updated: [Get Product](https://www.polyplugins.com/docs/content-api/api/get-product/) manage_stock attribute to return a bool
+* Updated: [Update Product](https://www.polyplugins.com/docs/content-api/api/update-product/) manage_stock attribute to be able to use bool
+* Updated: [Create Product](https://www.polyplugins.com/docs/content-api/api/create-product/) manage_stock attribute to be able to use bool
+* Bugfix: [Update Product](https://www.polyplugins.com/docs/content-api/api/update-product/) attributes attribute not creating product attributes when they don't exist.
+* Bugfix: [Create Product](https://www.polyplugins.com/docs/content-api/api/create-product/) attributes attribute not creating product attributes when they don't exist.
+* Bugfix: [Update Product](https://www.polyplugins.com/docs/content-api/api/update-product/) triggering error sku during slug check
+* Bugfix: [Create Product](https://www.polyplugins.com/docs/content-api/api/create-product/) triggering error sku during slug check
+* Bugfix: [Update Product](https://www.polyplugins.com/docs/content-api/api/update-product/) triggering Exception instead of WP Error when upc attribute is already in use
+* Bugfix: [Create Product](https://www.polyplugins.com/docs/content-api/api/create-product/) triggering Exception instead of WP Error when upc attribute is already in use
 
 = 1.0.10 =
 * Updated: [Create Product](https://www.polyplugins.com/docs/content-api/api/create-product/) endpoint to not require quantity


### PR DESCRIPTION
Updated: Update Product manage_stock attribute to be able to use bool
Updated: Create Product manage_stock attribute to be able to use bool
Bugfix: Update Product attributes attribute not creating product attributes when they don't exist.
Bugfix: Create Product attributes attribute not creating product attributes when they don't exist.
Bugfix: Update Product triggering error sku during slug check
Bugfix: Create Product triggering error sku during slug check
Bugfix: Update Product triggering Exception instead of WP Error when upc attribute is already in use
Bugfix: Create Product triggering Exception instead of WP Error when upc attribute is already in use