### PR TITLE
v1.1.0

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -65,6 +65,11 @@ Yes, the plugin supports uploading images to the WordPress media library via the
 
 ## Changelog
 
+### 1.1.0
+* Added: Ability to schedule posts using publish_on for [Create Post](https://www.polyplugins.com/docs/content-api/api/create-post/)
+* Updated: [Create Post](https://www.polyplugins.com/docs/content-api/api/create-post/) to only require title, content, and categories, as yoast and tags aren't a requirement.
+
+
 ### 1.0.11
 * Updated: [Get Product](https://www.polyplugins.com/docs/content-api/api/get-product/) manage_stock attribute to return a bool
 * Updated: [Update Product](https://www.polyplugins.com/docs/content-api/api/update-product/) manage_stock attribute to be able to use bool

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: polyplugins
 Tags: content api, rest api, content, creative, api
 Tested up to: 6.8
-Stable tag: 1.0.11
+Stable tag: 1.1.0
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -83,6 +83,10 @@ Yes, the plugin supports uploading images to the WordPress media library via the
 
 
 == Changelog ==
+
+= 1.1.0 =
+* Added: Ability to schedule posts using publish_on for [Create Post](https://www.polyplugins.com/docs/content-api/api/create-post/)
+* Updated: [Create Post](https://www.polyplugins.com/docs/content-api/api/create-post/) to only require title, content, and categories
 
 = 1.0.11 =
 * Updated: [Get Product](https://www.polyplugins.com/docs/content-api/api/get-product/) manage_stock attribute to return a bool


### PR DESCRIPTION
* Added: Ability to schedule posts using publish_on for [Create Post](https://www.polyplugins.com/docs/content-api/api/create-post/)
* Updated: [Create Post](https://www.polyplugins.com/docs/content-api/api/create-post/) to only require title, content, and categories, as yoast and tags aren't a requirement.